### PR TITLE
Update to msal v2.0.1-preview

### DIFF
--- a/active-directory-b2c-dotnet-uwp/App.xaml.cs
+++ b/active-directory-b2c-dotnet-uwp/App.xaml.cs
@@ -104,7 +104,7 @@ namespace active_directory_b2c_dotnet_uwp
         public static string PolicyEditProfile = "b2c_1_edit_profile";
         public static string PolicyResetPassword = "b2c_1_reset";
 
-        public static string[] ApiScopes = { "https://fabrikamb2c.onmicrosoft.com/demoapi/demo.read" };
+        public static string[] ApiScopes = { "https://fabrikamb2c.onmicrosoft.com/demoapi/demo.read"};
         public static string ApiEndpoint = "https://fabrikamb2chello.azurewebsites.net/hello";
 
         private static string BaseAuthority = "https://login.microsoftonline.com/tfp/{tenant}/{policy}/oauth2/v2.0/authorize";
@@ -112,8 +112,6 @@ namespace active_directory_b2c_dotnet_uwp
         public static string AuthorityEditProfile = BaseAuthority.Replace("{tenant}", Tenant).Replace("{policy}", PolicyEditProfile);
         public static string AuthorityResetPassword = BaseAuthority.Replace("{tenant}", Tenant).Replace("{policy}", PolicyResetPassword);
 
-        private static PublicClientApplication _clientApp = new PublicClientApplication(ClientId, Authority);
-
-        public static PublicClientApplication PublicClientApp { get { return _clientApp; } }
+        public static PublicClientApplication PublicClientApp { get; } = new PublicClientApplication(ClientId, Authority);
     }
 }

--- a/active-directory-b2c-dotnet-uwp/MainPage.xaml.cs
+++ b/active-directory-b2c-dotnet-uwp/MainPage.xaml.cs
@@ -39,7 +39,7 @@ namespace active_directory_b2c_dotnet_uwp
             IEnumerable<IAccount> accounts = await App.PublicClientApp.GetAccountsAsync();
             try
             {
-                IAccount currentUserAccount = GetUserByPolicy(accounts, App.PolicySignUpSignIn);
+                IAccount currentUserAccount = GetAccountByPolicy(accounts, App.PolicySignUpSignIn);
                 authResult = await App.PublicClientApp.AcquireTokenSilentAsync(App.ApiScopes, currentUserAccount, App.Authority, false);
 
                 DisplayBasicTokenInfo(authResult);
@@ -47,7 +47,7 @@ namespace active_directory_b2c_dotnet_uwp
             }
             catch (MsalUiRequiredException ex)
             {
-                authResult = await App.PublicClientApp.AcquireTokenAsync(App.ApiScopes, GetUserByPolicy(accounts, App.PolicySignUpSignIn), UIBehavior.SelectAccount, string.Empty, null, App.Authority);
+                authResult = await App.PublicClientApp.AcquireTokenAsync(App.ApiScopes, GetAccountByPolicy(accounts, App.PolicySignUpSignIn), UIBehavior.SelectAccount, string.Empty, null, App.Authority);
                 DisplayBasicTokenInfo(authResult);
                 UpdateSignInState(true);
             }
@@ -58,14 +58,13 @@ namespace active_directory_b2c_dotnet_uwp
             }
         }
 
-
         private async void EditProfileButton_Click(object sender, RoutedEventArgs e)
         {
             try
             {
                 IEnumerable<IAccount> accounts = await App.PublicClientApp.GetAccountsAsync();
                 ResultText.Text = $"Calling API:{App.AuthorityEditProfile}";
-                AuthenticationResult authResult = await App.PublicClientApp.AcquireTokenAsync(App.ApiScopes, GetUserByPolicy(accounts, App.PolicyEditProfile), UIBehavior.SelectAccount, string.Empty, null, App.AuthorityEditProfile);
+                AuthenticationResult authResult = await App.PublicClientApp.AcquireTokenAsync(App.ApiScopes, GetAccountByPolicy(accounts, App.PolicyEditProfile), UIBehavior.SelectAccount, string.Empty, null, App.AuthorityEditProfile);
                 DisplayBasicTokenInfo(authResult);
             }
             catch (Exception ex)
@@ -81,7 +80,7 @@ namespace active_directory_b2c_dotnet_uwp
             try
             {
 
-                authResult = await App.PublicClientApp.AcquireTokenSilentAsync(App.ApiScopes, GetUserByPolicy(accounts, App.PolicySignUpSignIn), App.Authority, false);
+                authResult = await App.PublicClientApp.AcquireTokenSilentAsync(App.ApiScopes, GetAccountByPolicy(accounts, App.PolicySignUpSignIn), App.Authority, false);
             }
             catch (MsalUiRequiredException ex)
             {
@@ -90,7 +89,7 @@ namespace active_directory_b2c_dotnet_uwp
 
                 try
                 {
-                    authResult = await App.PublicClientApp.AcquireTokenAsync(App.ApiScopes, GetUserByPolicy(accounts, App.PolicySignUpSignIn));
+                    authResult = await App.PublicClientApp.AcquireTokenAsync(App.ApiScopes, GetAccountByPolicy(accounts, App.PolicySignUpSignIn));
                 }
                 catch (MsalException msalex)
                 {
@@ -198,7 +197,7 @@ namespace active_directory_b2c_dotnet_uwp
             {
                 IEnumerable<IAccount> accounts = await App.PublicClientApp.GetAccountsAsync();
 
-                AuthenticationResult authResult = await App.PublicClientApp.AcquireTokenSilentAsync(App.ApiScopes, GetUserByPolicy(accounts, App.PolicySignUpSignIn), App.Authority, true);
+                AuthenticationResult authResult = await App.PublicClientApp.AcquireTokenSilentAsync(App.ApiScopes, GetAccountByPolicy(accounts, App.PolicySignUpSignIn), App.Authority, true);
                 DisplayBasicTokenInfo(authResult);
                 UpdateSignInState(true);
             }
@@ -216,7 +215,7 @@ namespace active_directory_b2c_dotnet_uwp
             }
         }
 
-        private IAccount GetUserByPolicy(IEnumerable<IAccount> accounts, string policy)
+        private IAccount GetAccountByPolicy(IEnumerable<IAccount> accounts, string policy)
         {
             foreach (var account in accounts)
             {

--- a/active-directory-b2c-dotnet-uwp/project.json
+++ b/active-directory-b2c-dotnet-uwp/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
-    "Microsoft.Identity.Client": "1.1.0-preview",
+    "Microsoft.Identity.Client": "2.0.1-preview",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.3"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10586": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/active-directory-b2c-dotnet-uwp/project.json
+++ b/active-directory-b2c-dotnet-uwp/project.json
@@ -4,7 +4,7 @@
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.3"
   },
   "frameworks": {
-    "uap10.0.10586": {}
+    "uap10.0": {}
   },
   "runtimes": {
     "win10-arm": {},


### PR DESCRIPTION
Tested w/Google, FB, Twitter, and Microsoft accounts.
Can confirm that accounts are now deleted in relation to this [MSAL issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/613) and the `MsalUiRequiredException` is being thrown on the silent calls.

